### PR TITLE
Update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Derive version string
         id: bin_version
         run: echo "bin_version=$(./.version.sh)" >> "$GITHUB_OUTPUT"
@@ -78,15 +78,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run MegaLinter
-        uses: oxsecurity/megalinter@v7
+        uses: oxsecurity/megalinter@v9
         env:
           # See https://megalinter.io/configuration and .mega-linter.yml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Archive MegaLinter artifacts
         if: ( !env.ACT && ( success() || failure() ) )
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MegaLinter artifacts
           path: |
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -123,7 +123,7 @@ jobs:
           cp ./*.deb ./gh-release/
           find . -name '${{ needs.meta.outputs.bin_name }}-*' -executable -type f -maxdepth 1 -print0 | xargs -0 -I {} tar --transform='flags=r;s|.*|${{ needs.meta.outputs.bin_name }}|' -czvf ./gh-release/{}.tar.gz {}
       - name: Upload binaries & packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
           path: out/gh-release/*
@@ -139,7 +139,7 @@ jobs:
       contents: write
     steps:
       - name: Download binaries & packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
           path: out
@@ -148,7 +148,7 @@ jobs:
         run: ls -R
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: out/${{ needs.meta.outputs.bin_name }}-*
           prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
@@ -164,9 +164,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Update running major/minor version tags
-        uses: sersoft-gmbh/running-release-tags-action@v3
+        uses: sersoft-gmbh/running-release-tags-action@v4
         with:
           fail-on-non-semver-tag: true
           create-release: false
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download binaries & packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
           path: out
@@ -188,7 +188,7 @@ jobs:
         working-directory: out
 
       - name: Login to Tailscale
-        uses: tailscale/github-action@v2
+        uses: tailscale/github-action@v4
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}


### PR DESCRIPTION
## Summary

Update all GitHub Actions in the workflow to their latest major versions.

## Action Updates

| Action | Old Version | New Version | Breaking Changes |
|--------|------------|-------------|------------------|
| `actions/checkout` | v4 | v6 | v5: Node 20 runtime. v6: Persist creds to separate file. No breaking changes for current usage. |
| `actions/upload-artifact` | v3 | v4 | v4 uses a new backend. Artifacts are no longer merged by default. No config changes needed. |
| `actions/download-artifact` | v3 | v4 | v4 uses new backend. Compatible with upload-artifact v4. |
| `oxsecurity/megalinter` | v7 | v9 | Major version jumps include various linter updates and config changes. Existing `.mega-linter.yml` should handle compatibility. |
| `softprops/action-gh-release` | v1 | v3 | v2: Node 20 runtime. v3: Node 24 runtime. No API changes. |
| `sersoft-gmbh/running-release-tags-action` | v3 | v4 | Node 20 runtime update. No API changes. |
| `tailscale/github-action` | v2 | v4 | v4: JavaScript implementation with Node 24. New ping parameter. Better DNS handling on macOS. Logs out ephemeral node at end of run. |

## Notes

- `ruby/setup-ruby@v1` - Already at latest major version (v1.x is the current line)
- `niniyas/ntfy-action@master` - No releases found; using master branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded GitHub Actions workflow automation tools to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->